### PR TITLE
Update class-automate-slack-invite-gravityforms.php

### DIFF
--- a/public/class-automate-slack-invite-gravityforms.php
+++ b/public/class-automate-slack-invite-gravityforms.php
@@ -72,7 +72,7 @@ class automate_slack_invite_gravityforms_public extends GFFeedAddOn {
                 'fields'      => array(
                     array(
                         'name'              => 'team_domain',
-                        'label'             => esc_html__( 'Team Name', 'automate-slack-invite-gravityforms' ),
+                        'label'             => esc_html__( 'Team Name, this is the name from the Slack URL', 'automate-slack-invite-gravityforms' ),
                         'type'              => 'text',
                         'class'             => 'large',
                         'feedback_callback' => array( $this, 'initialize_api' )


### PR DESCRIPTION
This is to clarify that the exact name as used in Slack, needs to be used for the team domain. If you use a team name with spaces it will cause an error in the Slack settings in Gravity Forms which is Request Failed. Array.
